### PR TITLE
Enable updating flatpak --user packages

### DIFF
--- a/pacup
+++ b/pacup
@@ -74,7 +74,7 @@ function PACUP_SYS() {
     echo -e "\nUpdating Flatpak packages..."
     pkgs="$(flatpak remote-ls --updates)"
     if [[ ! -z "$pkgs" ]]; then 
-      sudo flatpak update
+      flatpak update
     else
       echo "No updates available."
     fi


### PR DESCRIPTION
Since you expressed an interest in supporting this:

Don't run `flatpak update` as root, it's not needed for packages installed as a user, and it will elevate privileges itself for system packages.